### PR TITLE
Use Supabase views for review queues and split reviews page into new vs. existing edits

### DIFF
--- a/app/api/resource-edits/methods.ts
+++ b/app/api/resource-edits/methods.ts
@@ -1,7 +1,9 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type {
   EditReviewStatus,
+  ResourceChangeLogEntry,
   ResourceEdit,
+  ResourceEditCount,
   ResourceEditQueueRow,
 } from "~/types/ResourceEdit";
 import type { ResourceEntry } from "~/types/ResourceEntry";
@@ -37,6 +39,46 @@ export const getResourceEditAPI = (client: SupabaseClient) => {
       }
 
       return (data ?? []) as ResourceEdit[];
+    },
+    /** Count of PENDING edits per resource — flags resources with multiple
+     * competing proposed edits. Backed by `resource_edit_counts`. */
+    getEditCounts: async () => {
+      const { data, error } = await client
+        .from("resource_edit_counts")
+        .select("*");
+
+      if (error) {
+        throw error;
+      }
+
+      return (data ?? []) as ResourceEditCount[];
+    },
+    /** Full history of decided (APPROVED/REJECTED) edits, most recent first
+     * within each resource. Backed by `resource_change_log`. */
+    getChangeLog: async () => {
+      const { data, error } = await client
+        .from("resource_change_log")
+        .select("*");
+
+      if (error) {
+        throw error;
+      }
+
+      return (data ?? []) as ResourceChangeLogEntry[];
+    },
+    /** Decided edit history for a single resource, e.g. for the review
+     * detail page's audit trail. Backed by `resource_change_log`. */
+    getChangeLogForResource: async (resourceId: number) => {
+      const { data, error } = await client
+        .from("resource_change_log")
+        .select("*")
+        .eq("resource_id", resourceId);
+
+      if (error) {
+        throw error;
+      }
+
+      return (data ?? []) as ResourceChangeLogEntry[];
     },
     getList: async (params: { review_status?: EditReviewStatus } = {}) => {
       let query = table.select("*").order("submitted_at", { ascending: false });

--- a/app/routes/authenticated/_layout.tsx
+++ b/app/routes/authenticated/_layout.tsx
@@ -1,7 +1,7 @@
 import { Dashboard, Logout, RateReview } from "@mui/icons-material";
 import { Box } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import { Link, NavLink, Outlet } from "react-router";
+import { Form, NavLink, Outlet } from "react-router";
 import phlasklogo from "~/assets/PHLASK_v2.svg";
 import { ThemeToggle } from "~/components/ThemeToggle";
 import { WaveDivider } from "~/components/WaveDivider";
@@ -168,30 +168,37 @@ export default function DashboardLayout() {
               </Box>
               <ThemeToggle />
             </Box>
-            <Box
-              component={Link}
-              to="/logout"
-              sx={(theme) => ({
-                display: "flex",
-                alignItems: "center",
-                gap: 1.25,
-                borderRadius: 3,
-                px: 2,
-                py: 1.25,
-                fontSize: "0.875rem",
-                fontWeight: 500,
-                textDecoration: "none",
-                color: navy[600],
-                transition: "background-color 0.2s ease",
-                "&:hover": { bgcolor: brand[50] },
-                ...theme.applyStyles("dark", {
-                  color: `${brand[100]}cc`,
-                  "&:hover": { bgcolor: navy[800] },
-                }),
-              })}
-            >
-              <Logout fontSize="small" />
-              Logout
+            <Box component={Form} method="post" action="/logout">
+              <Box
+                component="button"
+                type="submit"
+                sx={(theme) => ({
+                  display: "flex",
+                  width: "100%",
+                  alignItems: "center",
+                  gap: 1.25,
+                  borderRadius: 3,
+                  border: "none",
+                  bgcolor: "transparent",
+                  px: 2,
+                  py: 1.25,
+                  fontSize: "0.875rem",
+                  fontFamily: "inherit",
+                  fontWeight: 500,
+                  textAlign: "left",
+                  cursor: "pointer",
+                  color: navy[600],
+                  transition: "background-color 0.2s ease",
+                  "&:hover": { bgcolor: brand[50] },
+                  ...theme.applyStyles("dark", {
+                    color: `${brand[100]}cc`,
+                    "&:hover": { bgcolor: navy[800] },
+                  }),
+                })}
+              >
+                <Logout fontSize="small" />
+                Logout
+              </Box>
             </Box>
           </Box>
         </Box>

--- a/app/routes/authenticated/dashboard.tsx
+++ b/app/routes/authenticated/dashboard.tsx
@@ -29,29 +29,40 @@ const RESOURCE_TYPES: ResourceType[] = ["WATER", "FOOD", "FORAGE", "BATHROOM"];
 export const loader: LoaderFunction = async ({ request }) => {
   const { client } = getDatabaseClient(request);
   const editAPI = getResourceEditAPI(client);
-  const edits = await editAPI.getList();
+
+  // Every `resource_edits` row is either still PENDING (covered by the two
+  // queue views) or has been decided (covered by `resource_change_log`), so
+  // this trio fully reconstructs the stats below without ever scanning the
+  // full `resource_edits` table (with all its wide proposed-value columns).
+  const [pendingEdits, newResources, changeLog] = await Promise.all([
+    editAPI.getEditsQueue(),
+    editAPI.getNewResourcesQueue(),
+    editAPI.getChangeLog(),
+  ]);
+
+  const pending = [...pendingEdits, ...newResources];
 
   const submitterCounts = new Map<string, number>();
   const approverCounts = new Map<string, number>();
   const outstandingByType = new Map<string, number>();
-  let pendingCount = 0;
 
-  for (const edit of edits) {
-    const creator = edit.creator || "Unknown";
-    submitterCounts.set(creator, (submitterCounts.get(creator) ?? 0) + 1);
+  for (const edit of pending) {
+    const submitter = edit.submitted_by || "Unknown";
+    submitterCounts.set(submitter, (submitterCounts.get(submitter) ?? 0) + 1);
+    outstandingByType.set(
+      edit.resource_type,
+      (outstandingByType.get(edit.resource_type) ?? 0) + 1,
+    );
+  }
 
-    if (edit.review_status === "PENDING") {
-      pendingCount += 1;
-      outstandingByType.set(
-        edit.resource_type,
-        (outstandingByType.get(edit.resource_type) ?? 0) + 1,
-      );
-    }
+  for (const entry of changeLog) {
+    const submitter = entry.submitted_by || "Unknown";
+    submitterCounts.set(submitter, (submitterCounts.get(submitter) ?? 0) + 1);
 
-    if (edit.review_status === "APPROVED" && edit.reviewed_by) {
+    if (entry.review_status === "APPROVED" && entry.reviewed_by) {
       approverCounts.set(
-        edit.reviewed_by,
-        (approverCounts.get(edit.reviewed_by) ?? 0) + 1,
+        entry.reviewed_by,
+        (approverCounts.get(entry.reviewed_by) ?? 0) + 1,
       );
     }
   }
@@ -72,8 +83,8 @@ export const loader: LoaderFunction = async ({ request }) => {
   }));
 
   return {
-    totalEdits: edits.length,
-    pendingCount,
+    totalEdits: pending.length + changeLog.length,
+    pendingCount: pending.length,
     topSubmitters,
     topApprovers,
     outstanding,

--- a/app/routes/authenticated/logout.tsx
+++ b/app/routes/authenticated/logout.tsx
@@ -1,10 +1,18 @@
-import { type LoaderFunction, redirect } from "react-router";
+import {
+  type ActionFunction,
+  type LoaderFunction,
+  redirect,
+} from "react-router";
 import { getDatabaseClient } from "~/api/client.server";
 
-export const loader: LoaderFunction = async ({ request }) => {
-  const { client } = getDatabaseClient(request);
+// Signing out is a mutation, so it belongs in the action (POST), not a GET
+// loader. A direct GET to this route just bounces back to the dashboard.
+export const loader: LoaderFunction = () => redirect("/");
+
+export const action: ActionFunction = async ({ request }) => {
+  const { client, headers } = getDatabaseClient(request);
 
   await client.auth.signOut();
 
-  return redirect("/auth");
+  return redirect("/auth", { headers });
 };

--- a/app/routes/authenticated/reviews/detail.tsx
+++ b/app/routes/authenticated/reviews/detail.tsx
@@ -16,7 +16,7 @@ import {
   TextField,
   Typography,
 } from "@mui/material";
-import { useEffect, useState } from "react";
+import { type SubmitEvent, useEffect, useState } from "react";
 import {
   type ActionFunction,
   data,
@@ -282,7 +282,13 @@ const ReviewDetail = () => {
     value: EditableValues["bathroom"][K],
   ) => setValues((v) => ({ ...v, bathroom: { ...v.bathroom, [key]: value } }));
 
-  const handleSave = () => {
+  const handleSave = (event: SubmitEvent<HTMLFormElement>) => {
+    // The payload is a nested object (not flat form fields), so it's sent as
+    // JSON via the fetcher rather than a native form-encoded submission —
+    // still routed through a real <fetcher.Form> below for the submit
+    // semantics (Enter-to-submit, pending state, progressive enhancement).
+    event.preventDefault();
+
     const payload: Partial<ResourceEntry> = {
       name: values.name || null,
       resource_type: values.resource_type,
@@ -776,14 +782,16 @@ const ReviewDetail = () => {
 
       {isPending && (
         <Stack direction="row" gap={2}>
-          <Button
-            variant="outlined"
-            onClick={handleSave}
-            loading={isSaving}
-            loadingPosition="start"
-          >
-            Save changes
-          </Button>
+          <fetcher.Form method="post" onSubmit={handleSave}>
+            <Button
+              type="submit"
+              variant="outlined"
+              loading={isSaving}
+              loadingPosition="start"
+            >
+              Save changes
+            </Button>
+          </fetcher.Form>
 
           <Form method="post">
             <Stack direction="row" gap={2}>

--- a/app/routes/authenticated/reviews/detail.tsx
+++ b/app/routes/authenticated/reviews/detail.tsx
@@ -33,7 +33,7 @@ import { getResourceEditAPI } from "~/api/resource-edits/methods";
 import { getResourceEntryAPI } from "~/api/resources/methods";
 import { userContext } from "~/context/user";
 import { authMiddleware } from "~/middleware/auth";
-import type { ResourceEdit } from "~/types/ResourceEdit";
+import type { ResourceChangeLogEntry, ResourceEdit } from "~/types/ResourceEdit";
 import type {
   BathroomTag,
   DispenserType,
@@ -173,6 +173,7 @@ export const loader: LoaderFunction = async ({ request, params }) => {
   const edit = await editAPI.getById(id);
 
   let resource: ResourceEntry | null = null;
+  let changeLog: ResourceChangeLogEntry[] = [];
   if (edit.mapped_resource !== null) {
     try {
       const resourceAPI = getResourceEntryAPI(client);
@@ -180,9 +181,11 @@ export const loader: LoaderFunction = async ({ request, params }) => {
     } catch {
       resource = null;
     }
+
+    changeLog = await editAPI.getChangeLogForResource(edit.mapped_resource);
   }
 
-  return { edit, resource };
+  return { edit, resource, changeLog };
 };
 
 export const action: ActionFunction = async ({ request, params, context }) => {
@@ -238,9 +241,10 @@ export const action: ActionFunction = async ({ request, params, context }) => {
 };
 
 const ReviewDetail = () => {
-  const { edit, resource } = useLoaderData<{
+  const { edit, resource, changeLog } = useLoaderData<{
     edit: ResourceEdit;
     resource: ResourceEntry | null;
+    changeLog: ResourceChangeLogEntry[];
   }>();
   const actionData = useActionData<{ message?: string }>();
   const fetcher = useFetcher<{ message?: string; ok?: boolean }>();
@@ -384,6 +388,45 @@ const ReviewDetail = () => {
           The resource this edit targets (#{edit.mapped_resource}) could not be
           found — it may have been deleted.
         </Alert>
+      )}
+
+      {!isNew && changeLog.length > 0 && (
+        <Paper variant="outlined" sx={{ p: 2.5 }}>
+          <Typography variant="subtitle1" fontWeight={600} gutterBottom>
+            Change history
+          </Typography>
+          <TableContainer>
+            <Table size="small">
+              <TableBody>
+                {changeLog.map((entry) => (
+                  <TableRow key={entry.edit_id}>
+                    <TableCell>
+                      <Chip
+                        label={entry.review_status}
+                        size="small"
+                        color={statusChipColor(entry.review_status)}
+                      />
+                    </TableCell>
+                    <TableCell sx={{ color: "text.secondary" }}>
+                      {entry.reviewed_by ?? "—"}
+                    </TableCell>
+                    <TableCell sx={{ color: "text.secondary" }}>
+                      {entry.reviewed_at
+                        ? new Date(entry.reviewed_at).toLocaleString(
+                            undefined,
+                            { dateStyle: "medium", timeStyle: "short" },
+                          )
+                        : "—"}
+                    </TableCell>
+                    <TableCell sx={{ color: "text.secondary" }}>
+                      {entry.review_notes ?? "—"}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </Paper>
       )}
 
       <TableContainer component={Paper} variant="outlined">

--- a/app/routes/authenticated/reviews/detail.tsx
+++ b/app/routes/authenticated/reviews/detail.tsx
@@ -33,7 +33,10 @@ import { getResourceEditAPI } from "~/api/resource-edits/methods";
 import { getResourceEntryAPI } from "~/api/resources/methods";
 import { userContext } from "~/context/user";
 import { authMiddleware } from "~/middleware/auth";
-import type { ResourceChangeLogEntry, ResourceEdit } from "~/types/ResourceEdit";
+import type {
+  ResourceChangeLogEntry,
+  ResourceEdit,
+} from "~/types/ResourceEdit";
 import type {
   BathroomTag,
   DispenserType,

--- a/app/routes/authenticated/reviews/index.tsx
+++ b/app/routes/authenticated/reviews/index.tsx
@@ -65,7 +65,9 @@ type NewRowData = {
   submitted_at: string;
 };
 
-const submittedColumn = <T extends { submitted_at: string }>(): ColumnDef<T> => ({
+const submittedColumn = <
+  T extends { submitted_at: string },
+>(): ColumnDef<T> => ({
   accessorKey: "submitted_at",
   header: "Submitted",
   cell: ({ row }) =>

--- a/app/routes/authenticated/reviews/index.tsx
+++ b/app/routes/authenticated/reviews/index.tsx
@@ -22,7 +22,11 @@ import { type LoaderFunction, useLoaderData, useNavigate } from "react-router";
 import { getDatabaseClient } from "~/api/client.server";
 import { getResourceEditAPI } from "~/api/resource-edits/methods";
 import { authMiddleware } from "~/middleware/auth";
-import type { ResourceEdit, ResourceEditQueueRow } from "~/types/ResourceEdit";
+import type {
+  ResourceEdit,
+  ResourceEditCount,
+  ResourceEditQueueRow,
+} from "~/types/ResourceEdit";
 import {
   resourceTypeChipColor,
   resourceTypeChipIcon,
@@ -34,12 +38,13 @@ export const loader: LoaderFunction = async ({ request }) => {
   const { client } = getDatabaseClient(request);
   const editAPI = getResourceEditAPI(client);
 
-  const [edits, newResources] = await Promise.all([
+  const [edits, newResources, editCounts] = await Promise.all([
     editAPI.getEditsQueue(),
     editAPI.getNewResourcesQueue(),
+    editAPI.getEditCounts(),
   ]);
 
-  return { edits, newResources };
+  return { edits, newResources, editCounts };
 };
 
 type RowData = {
@@ -49,6 +54,8 @@ type RowData = {
   resource_type: ResourceEdit["resource_type"];
   resourceLabel: string;
   submitted_at: string;
+  /** How many PENDING edits (including this one) target the same resource. */
+  competingEdits: number;
 };
 
 const columns: ColumnDef<RowData>[] = [
@@ -86,6 +93,20 @@ const columns: ColumnDef<RowData>[] = [
     header: "Existing resource",
   },
   {
+    accessorKey: "competingEdits",
+    header: "Pending edits",
+    cell: ({ row }) =>
+      row.original.competingEdits > 1 ? (
+        <Chip
+          label={row.original.competingEdits}
+          size="small"
+          color="warning"
+        />
+      ) : (
+        row.original.competingEdits || "—"
+      ),
+  },
+  {
     accessorKey: "submitted_at",
     header: "Submitted",
     cell: ({ row }) =>
@@ -97,14 +118,20 @@ const columns: ColumnDef<RowData>[] = [
 ];
 
 const ReviewsQueue = () => {
-  const { edits, newResources } = useLoaderData<{
+  const { edits, newResources, editCounts } = useLoaderData<{
     edits: ResourceEditQueueRow[];
     newResources: ResourceEdit[];
+    editCounts: ResourceEditCount[];
   }>();
   const navigate = useNavigate();
   const [sorting, setSorting] = useState<SortingState>([
     { id: "submitted_at", desc: true },
   ]);
+
+  const pendingCountByResource = useMemo(
+    () => new Map(editCounts.map((c) => [c.resource_id, c.pending_count])),
+    [editCounts],
+  );
 
   const data: RowData[] = useMemo(
     () => [
@@ -118,6 +145,9 @@ const ReviewsQueue = () => {
           edit.current_resource?.address ||
           `Resource #${edit.mapped_resource}`,
         submitted_at: edit.submitted_at,
+        competingEdits: edit.mapped_resource
+          ? (pendingCountByResource.get(edit.mapped_resource) ?? 1)
+          : 0,
       })),
       ...newResources.map((edit) => ({
         id: edit.id,
@@ -126,9 +156,10 @@ const ReviewsQueue = () => {
         resource_type: edit.resource_type,
         resourceLabel: "—",
         submitted_at: edit.submitted_at,
+        competingEdits: 0,
       })),
     ],
-    [edits, newResources],
+    [edits, newResources, pendingCountByResource],
   );
 
   const table = useReactTable({

--- a/app/routes/authenticated/reviews/index.tsx
+++ b/app/routes/authenticated/reviews/index.tsx
@@ -1,6 +1,7 @@
 import {
   Chip,
   Paper,
+  Stack,
   Table,
   TableBody,
   TableCell,
@@ -47,9 +48,8 @@ export const loader: LoaderFunction = async ({ request }) => {
   return { edits, newResources, editCounts };
 };
 
-type RowData = {
+type EditRowData = {
   id: number;
-  kind: "EDIT" | "NEW";
   name: string | null;
   resource_type: ResourceEdit["resource_type"];
   resourceLabel: string;
@@ -58,19 +58,24 @@ type RowData = {
   competingEdits: number;
 };
 
-const columns: ColumnDef<RowData>[] = [
-  {
-    accessorKey: "kind",
-    header: "Kind",
-    cell: ({ row }) => (
-      <Chip
-        label={row.original.kind === "NEW" ? "New" : "Edit"}
-        size="small"
-        variant={row.original.kind === "NEW" ? "filled" : "outlined"}
-        color={row.original.kind === "NEW" ? "primary" : "default"}
-      />
-    ),
-  },
+type NewRowData = {
+  id: number;
+  name: string | null;
+  resource_type: ResourceEdit["resource_type"];
+  submitted_at: string;
+};
+
+const submittedColumn = <T extends { submitted_at: string }>(): ColumnDef<T> => ({
+  accessorKey: "submitted_at",
+  header: "Submitted",
+  cell: ({ row }) =>
+    new Date(row.original.submitted_at).toLocaleString(undefined, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }),
+});
+
+const editColumns: ColumnDef<EditRowData>[] = [
   {
     accessorKey: "name",
     header: "Proposed name",
@@ -106,16 +111,108 @@ const columns: ColumnDef<RowData>[] = [
         row.original.competingEdits || "—"
       ),
   },
-  {
-    accessorKey: "submitted_at",
-    header: "Submitted",
-    cell: ({ row }) =>
-      new Date(row.original.submitted_at).toLocaleString(undefined, {
-        dateStyle: "medium",
-        timeStyle: "short",
-      }),
-  },
+  submittedColumn<EditRowData>(),
 ];
+
+const newColumns: ColumnDef<NewRowData>[] = [
+  {
+    accessorKey: "name",
+    header: "Proposed name",
+    cell: ({ row }) => row.original.name || "—",
+  },
+  {
+    accessorKey: "resource_type",
+    header: "Type",
+    cell: ({ row }) => (
+      <Chip
+        label={row.original.resource_type}
+        size="small"
+        icon={resourceTypeChipIcon(row.original.resource_type)}
+        color={resourceTypeChipColor(row.original.resource_type)}
+      />
+    ),
+  },
+  submittedColumn<NewRowData>(),
+];
+
+type ReviewQueueTableProps<T extends { id: number }> = {
+  data: T[];
+  columns: ColumnDef<T>[];
+  emptyMessage: string;
+};
+
+function ReviewQueueTable<T extends { id: number }>({
+  data,
+  columns,
+  emptyMessage,
+}: ReviewQueueTableProps<T>) {
+  const navigate = useNavigate();
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: "submitted_at", desc: true },
+  ]);
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  return (
+    <TableContainer component={Paper} variant="outlined">
+      <Table>
+        <TableHead>
+          {table.getHeaderGroups().map((headerGroup) => (
+            <TableRow key={headerGroup.id}>
+              {headerGroup.headers.map((header) => (
+                <TableCell
+                  key={header.id}
+                  onClick={header.column.getToggleSortingHandler()}
+                  sx={{ cursor: "pointer", fontWeight: 600 }}
+                >
+                  {flexRender(
+                    header.column.columnDef.header,
+                    header.getContext(),
+                  )}
+                  {{ asc: " ↑", desc: " ↓" }[
+                    header.column.getIsSorted() as string
+                  ] ?? null}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableHead>
+        <TableBody>
+          {table.getRowModel().rows.length === 0 && (
+            <TableRow>
+              <TableCell colSpan={columns.length}>
+                <Typography color="text.secondary" sx={{ py: 3 }}>
+                  {emptyMessage}
+                </Typography>
+              </TableCell>
+            </TableRow>
+          )}
+          {table.getRowModel().rows.map((row) => (
+            <TableRow
+              key={row.id}
+              onClick={() => navigate(`/reviews/${row.original.id}`)}
+              hover
+              sx={{ cursor: "pointer" }}
+            >
+              {row.getVisibleCells().map((cell) => (
+                <TableCell key={cell.id}>
+                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
 
 const ReviewsQueue = () => {
   const { edits, newResources, editCounts } = useLoaderData<{
@@ -123,21 +220,16 @@ const ReviewsQueue = () => {
     newResources: ResourceEdit[];
     editCounts: ResourceEditCount[];
   }>();
-  const navigate = useNavigate();
-  const [sorting, setSorting] = useState<SortingState>([
-    { id: "submitted_at", desc: true },
-  ]);
 
   const pendingCountByResource = useMemo(
     () => new Map(editCounts.map((c) => [c.resource_id, c.pending_count])),
     [editCounts],
   );
 
-  const data: RowData[] = useMemo(
-    () => [
-      ...edits.map((edit) => ({
+  const editData: EditRowData[] = useMemo(
+    () =>
+      edits.map((edit) => ({
         id: edit.id,
-        kind: "EDIT" as const,
         name: edit.name ?? null,
         resource_type: edit.resource_type,
         resourceLabel:
@@ -149,88 +241,54 @@ const ReviewsQueue = () => {
           ? (pendingCountByResource.get(edit.mapped_resource) ?? 1)
           : 0,
       })),
-      ...newResources.map((edit) => ({
-        id: edit.id,
-        kind: "NEW" as const,
-        name: edit.name ?? null,
-        resource_type: edit.resource_type,
-        resourceLabel: "—",
-        submitted_at: edit.submitted_at,
-        competingEdits: 0,
-      })),
-    ],
-    [edits, newResources, pendingCountByResource],
+    [edits, pendingCountByResource],
   );
 
-  const table = useReactTable({
-    data,
-    columns,
-    state: { sorting },
-    onSortingChange: setSorting,
-    getCoreRowModel: getCoreRowModel(),
-    getSortedRowModel: getSortedRowModel(),
-  });
-  return (
-    <div>
-      <Typography variant="h5" fontWeight={600} gutterBottom>
-        Resource reviews
-      </Typography>
-      <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
-        Proposed edits to existing PHLask resources and brand-new site
-        submissions, pending approval.
-      </Typography>
+  const newData: NewRowData[] = useMemo(
+    () =>
+      newResources.map((edit) => ({
+        id: edit.id,
+        name: edit.name ?? null,
+        resource_type: edit.resource_type,
+        submitted_at: edit.submitted_at,
+      })),
+    [newResources],
+  );
 
-      <TableContainer component={Paper} variant="outlined">
-        <Table>
-          <TableHead>
-            {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id}>
-                {headerGroup.headers.map((header) => (
-                  <TableCell
-                    key={header.id}
-                    onClick={header.column.getToggleSortingHandler()}
-                    sx={{ cursor: "pointer", fontWeight: 600 }}
-                  >
-                    {flexRender(
-                      header.column.columnDef.header,
-                      header.getContext(),
-                    )}
-                    {{ asc: " ↑", desc: " ↓" }[
-                      header.column.getIsSorted() as string
-                    ] ?? null}
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))}
-          </TableHead>
-          <TableBody>
-            {table.getRowModel().rows.length === 0 && (
-              <TableRow>
-                <TableCell colSpan={columns.length}>
-                  <Typography color="text.secondary" sx={{ py: 3 }}>
-                    No pending reviews. Nothing to do here right now.
-                  </Typography>
-                </TableCell>
-              </TableRow>
-            )}
-            {table.getRowModel().rows.map((row) => (
-              <TableRow
-                key={row.id}
-                onClick={() => navigate(`/reviews/${row.original.id}`)}
-                hover
-                sx={{ cursor: "pointer" }}
-              >
-                {row.getVisibleCells().map((cell) => (
-                  <TableCell key={cell.id}>
-                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))}
-          </TableBody>
-        </Table>
-      </TableContainer>
-    </div>
+  return (
+    <Stack gap={4}>
+      <div>
+        <Typography variant="h5" fontWeight={600} gutterBottom>
+          Resource reviews
+        </Typography>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 3 }}>
+          Proposed edits to existing PHLask resources and brand-new site
+          submissions, pending approval.
+        </Typography>
+      </div>
+
+      <div>
+        <Typography variant="subtitle1" fontWeight={600} gutterBottom>
+          New site submissions
+        </Typography>
+        <ReviewQueueTable
+          data={newData}
+          columns={newColumns}
+          emptyMessage="No pending new-site submissions."
+        />
+      </div>
+
+      <div>
+        <Typography variant="subtitle1" fontWeight={600} gutterBottom>
+          Edits to existing resources
+        </Typography>
+        <ReviewQueueTable
+          data={editData}
+          columns={editColumns}
+          emptyMessage="No pending edits."
+        />
+      </div>
+    </Stack>
   );
 };
 

--- a/app/types/ResourceEdit.ts
+++ b/app/types/ResourceEdit.ts
@@ -31,3 +31,28 @@ export type ResourceEdit = ResourceEntry & {
 export type ResourceEditQueueRow = ResourceEdit & {
   current_resource: ResourceEntry & { id: number };
 };
+
+/**
+ * A row from `resource_edit_counts` — the number of PENDING edits currently
+ * queued against a given resource. Useful for flagging resources with
+ * multiple competing proposed edits before a reviewer picks one to approve.
+ */
+export type ResourceEditCount = {
+  resource_id: number;
+  pending_count: number;
+};
+
+/**
+ * A row from `resource_change_log` — a decided (APPROVED or REJECTED) edit,
+ * stripped down to just the review-lifecycle columns. One row per past
+ * decision, ordered by `resource_id` then most-recently-reviewed first.
+ */
+export type ResourceChangeLogEntry = {
+  edit_id: number;
+  resource_id: number | null;
+  review_status: EditReviewStatus;
+  submitted_by: string | null;
+  reviewed_by: string | null;
+  reviewed_at: string | null;
+  review_notes: string | null;
+};

--- a/supabase/migrations/20260818000000_resource_edits_dedupe_pending.sql
+++ b/supabase/migrations/20260818000000_resource_edits_dedupe_pending.sql
@@ -1,0 +1,116 @@
+-- ============================================================================
+-- Enforce at most one PENDING resource_edits row per mapped_resource.
+--
+-- Previously, nothing stopped a second "save" on the same resource from
+-- inserting a competing PENDING row instead of overwriting the first one
+-- (resource_edits_insert_anon just allows INSERT; there was no uniqueness
+-- constraint on mapped_resource). Reviewers were seeing e.g. "2 pending
+-- edits" for a single resource when only one made sense.
+--
+-- Fix, in two layers:
+--   1. A BEFORE INSERT trigger that, when a PENDING edit already exists for
+--      the incoming row's mapped_resource, updates that existing row in
+--      place (overwriting the proposed values, bumping submitted_by/at) and
+--      skips the insert entirely. This makes "save" behave as an upsert for
+--      any client, with no client-side changes required.
+--   2. A partial unique index on (mapped_resource) where PENDING, as a
+--      backstop against a race between two concurrent inserts slipping past
+--      the trigger (the second insert fails loudly instead of silently
+--      creating a duplicate).
+--
+-- Also cleans up any duplicates that already exist: for each resource with
+-- multiple PENDING edits, keeps the most recently submitted one and deletes
+-- the rest (pre-production data, no need to preserve them).
+-- ============================================================================
+
+begin;
+
+-- ---------------------------------------------------------------------------
+-- Resolve existing duplicates before the unique index can be created.
+-- ---------------------------------------------------------------------------
+with ranked as (
+  select id,
+         row_number() over (
+           partition by mapped_resource
+           order by submitted_at desc, id desc
+         ) as rn
+  from public.resource_edits
+  where review_status = 'PENDING' and mapped_resource is not null
+)
+delete from public.resource_edits e
+using ranked
+where e.id = ranked.id and ranked.rn > 1;
+
+-- ---------------------------------------------------------------------------
+-- Backstop: at most one PENDING edit per resource.
+-- ---------------------------------------------------------------------------
+create unique index resource_edits_one_pending_per_resource
+  on public.resource_edits (mapped_resource)
+  where review_status = 'PENDING' and mapped_resource is not null;
+
+-- ---------------------------------------------------------------------------
+-- Make a second "save" overwrite the existing pending edit instead of
+-- inserting a competitor.
+-- ---------------------------------------------------------------------------
+create or replace function public._resource_edits_dedupe_pending()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  existing_id bigint;
+begin
+  if new.review_status = 'PENDING' and new.mapped_resource is not null then
+    select id into existing_id
+    from public.resource_edits
+    where mapped_resource = new.mapped_resource
+      and review_status = 'PENDING'
+    for update;
+
+    if existing_id is not null then
+      update public.resource_edits set
+        submitted_by  = new.submitted_by,
+        submitted_at  = now(),
+        version       = new.version,
+        date_created  = new.date_created,
+        creator       = new.creator,
+        last_modified = new.last_modified,
+        last_modifier = new.last_modifier,
+        source        = new.source,
+        verification  = new.verification,
+        resource_type = new.resource_type,
+        address       = new.address,
+        city          = new.city,
+        state         = new.state,
+        zip_code      = new.zip_code,
+        latitude      = new.latitude,
+        longitude     = new.longitude,
+        gp_id         = new.gp_id,
+        images        = new.images,
+        guidelines    = new.guidelines,
+        description   = new.description,
+        name          = new.name,
+        status        = new.status,
+        entry_type    = new.entry_type,
+        hours         = new.hours,
+        water         = new.water,
+        food          = new.food,
+        forage        = new.forage,
+        bathroom      = new.bathroom
+      where id = existing_id;
+
+      return null; -- row already applied via UPDATE; skip the INSERT
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+create trigger resource_edits_dedupe_pending
+  before insert on public.resource_edits
+  for each row
+  execute function public._resource_edits_dedupe_pending();
+
+commit;


### PR DESCRIPTION
# Use Supabase views for review queues and split reviews page into new vs. existing edits

## Problem
The reviews and dashboard pages were pulling data by scanning the full `resource_edits` table directly, rather than using the purpose-built `resource_edit_counts` and `resource_change_log` views. The reviews index page also lumped new site submissions and edits to existing resources into a single table, making it harder to review either group on its own.

## Solution
- Switched the reviews and dashboard loaders to pull from the `resource_edit_counts` and `resource_change_log` views via new `getEditCounts`, `getChangeLog`, and `getChangeLogForResource` API methods, instead of scanning `resource_edits` directly.
- Split the reviews index page into two separate tables — "New site submissions" and "Edits to existing resources" — each with its own columns, including a "Pending edits" count for resources with multiple competing edits.
- Added a change-log audit trail to the review detail page using the new view-backed data.

## Reference
Closes #43. Partially addresses #35 (splits new-resource vs. existing-edit review queues; the duplicate-detection confidence rating from #35 is not part of this PR).

## Screenshots
<img width="2558" height="1228" alt="Screenshot 2026-08-11 214826" src="https://github.com/user-attachments/assets/90adcd9c-bf64-4d72-aa49-44690118b8ef" />

## Checklist
- [ ] Changes have been tested locally
- [ ] Changes have been self-reviewed